### PR TITLE
Fix flake8

### DIFF
--- a/ear/core/direct_speakers/panner.py
+++ b/ear/core/direct_speakers/panner.py
@@ -105,7 +105,7 @@ class DirectSpeakersPanner(object):
         else:
             return None
 
-    @dispatch(DirectSpeakerPolarPosition, float)
+    @dispatch(DirectSpeakerPolarPosition, float)  # noqa: F811
     def channels_within_bounds(self, position, tol):
         """Get a bit mask of channels within the bounds in position."""
 
@@ -126,7 +126,7 @@ class DirectSpeakersPanner(object):
             (self.distances > dist_min - tol) & (self.distances < dist_max + tol)
         )
 
-    @dispatch(DirectSpeakerCartesianPosition, float)
+    @dispatch(DirectSpeakerCartesianPosition, float)  # noqa: F811
     def channels_within_bounds(self, position, tol):
         """Get a bit mask of channels within the bounds in position."""
 
@@ -159,7 +159,7 @@ class DirectSpeakersPanner(object):
 
         return has_lfe_freq or has_lfe_name
 
-    @dispatch(DirectSpeakerPolarPosition)
+    @dispatch(DirectSpeakerPolarPosition)  # noqa: F811
     def apply_screen_edge_lock(self, position):
         az, el = self._screen_edge_lock_handler.handle_az_el(position.azimuth,
                                                              position.elevation,
@@ -169,7 +169,7 @@ class DirectSpeakersPanner(object):
                       bounded_azimuth=evolve(position.bounded_azimuth, value=az),
                       bounded_elevation=evolve(position.bounded_elevation, value=el))
 
-    @dispatch(DirectSpeakerCartesianPosition)
+    @dispatch(DirectSpeakerCartesianPosition)  # noqa: F811
     def apply_screen_edge_lock(self, position):
         X, Y, Z = self._screen_edge_lock_handler.handle_vector(position.as_cartesian_array(),
                                                                position.screenEdgeLock)

--- a/ear/fileio/adm/xml.py
+++ b/ear/fileio/adm/xml.py
@@ -112,9 +112,9 @@ def load_bool(data):
 
 StringType = TypeConvert(None, None)
 IntType = TypeConvert(int, str)
-FloatType = TypeConvert(float, "{:.5f}".format)
+FloatType = TypeConvert(float, "{:.5f}".format)  # noqa: P103
 SecondsType = TypeConvert(Fraction, lambda t: "{:07.5f}".format(float(t)))
-BoolType = TypeConvert(load_bool, "{:d}".format)
+BoolType = TypeConvert(load_bool, "{:d}".format)  # noqa: P103
 TimeType = TypeConvert(parse_time, unparse_time)
 RefType = TypeConvert(loads=None,
                       dumps=lambda data: data.id)

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ setup(
         'dev': [
             'flake8~=3.5',
             'flake8-print~=3.1',
-            'flake8-putty~=0.4',
             'flake8-string-format~=0.2',
         ],
     },

--- a/tox.ini
+++ b/tox.ini
@@ -25,8 +25,3 @@ ignore = E701,E702,E226,P101
 max-line-length = 160
 exclude = env*,.git,.tox
 doctests = true
-putty-ignore =
-    /@dispatch\(/ : F811
-    /# noqa: *(?P<codes>[A-Z0-9, ]*)/ : +(?P<codes>)
-    /# noqa$/ : +E201,E203,E241,E202
-    /".format/ : +P103


### PR DESCRIPTION
Remove flake8-putty, and manually ignore the lines which it fixed.

flake8-putty is not compatible with flake8 version 3. It's not really clear to me how I missed this, but running `pip check` would have been a good idea.