### PR TITLE
core/directspeakers: add warning for possible LFE errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
     - `audioBlockFormats` where the `rtime` plus the `duration` of one `audioBlockFormat` does not match the `rtime` of the next.
     - `interpolationTime` parameter larger than `duration`.
     - `audioBlockFormat` `rtime` plus `duration` extending past the end of the containing `audioObject`.
+- Issue a warning for `DirectSpeakers` blocks with a `speakerLabel` containing `LFE` which is not detected as an LFE channel. See [#9].
 
 ### Added
 - `loudnessMetadata` data structures, parsing and generation. See [#25].
@@ -128,6 +129,7 @@ Changes for ITU ADM renderer reference code.
 Initial release.
 
 [#8]: https://github.com/ebu/ebu_adm_renderer/pull/8
+[#9]: https://github.com/ebu/ebu_adm_renderer/pull/9
 [#12]: https://github.com/ebu/ebu_adm_renderer/pull/12
 [#13]: https://github.com/ebu/ebu_adm_renderer/pull/13
 [#22]: https://github.com/ebu/ebu_adm_renderer/pull/22

--- a/ear/core/direct_speakers/panner.py
+++ b/ear/core/direct_speakers/panner.py
@@ -403,6 +403,14 @@ class DirectSpeakersPanner(object):
 
         is_lfe_channel = self.is_lfe_channel(type_metadata)
 
+        if not is_lfe_channel and any("LFE" in l.upper() for l in block_format.speakerLabel):
+            warnings.warn(
+                "block {bf.id} not being treated as LFE, but has 'LFE' in a speakerLabel; "
+                "use an ITU speakerLabel or audioChannelFormat frequency element instead".format(
+                    bf=block_format
+                )
+            )
+
         if type_metadata.audioPackFormats is not None:
             pack = type_metadata.audioPackFormats[-1]
             if pack.is_common_definition and pack.id in itu_packs:


### PR DESCRIPTION
add a warning if there is a speakerlabel containing `LFE` but isn't an LFE according to the rules