### PR TITLE
fix gap at start of block processing channel

### DIFF
--- a/ear/core/renderer_common.py
+++ b/ear/core/renderer_common.py
@@ -67,8 +67,12 @@ class ProcessingBlock(object):
         overlap_start_sample = max(start_sample, self.first_sample)
         overlap_end_sample = min(end_sample, self.last_sample)
 
-        return (slice(overlap_start_sample - self.first_sample, overlap_end_sample - self.first_sample),
-                slice(overlap_start_sample - start_sample, overlap_end_sample - start_sample))
+        if overlap_start_sample <= overlap_end_sample:
+            return (slice(overlap_start_sample - self.first_sample, overlap_end_sample - self.first_sample),
+                    slice(overlap_start_sample - start_sample, overlap_end_sample - start_sample))
+        else:
+            # no overlap
+            return slice(0), slice(0)
 
 
 @attrs(slots=True, frozen=True)

--- a/ear/core/test/test_renderer_common.py
+++ b/ear/core/test/test_renderer_common.py
@@ -1,7 +1,10 @@
+from collections import namedtuple
 from fractions import Fraction
 import numpy as np
 import numpy.testing as npt
-from ..renderer_common import FixedGains, InterpGains
+import pytest
+from ..renderer_common import BlockProcessingChannel, FixedGains, InterpGains
+from ..metadata_input import MetadataSourceIter
 
 
 def test_FixedGains():
@@ -44,3 +47,64 @@ def test_InterpGains():
     g.process(0, input_samples, output_samples)
 
     npt.assert_allclose(output_samples, expected)
+
+
+@pytest.mark.parametrize("block_size", [5, 6, 10, 20, 60])
+def test_block_processing_channel(block_size):
+    # BlockProcessingChannel transforms metadata blocks into processing blocks;
+    # use a fake metadata block type which just holds the processing block.
+    DummyBlock = namedtuple("DummyBlock", "block")
+
+    # Check gap at start, between blocks, and at end. Try both FixedGains and
+    # InterpGains, since the behaviour with bad sample ranges may be different.
+    # The actual interpolation behaviour of these is tested above.
+    blocks = [
+        DummyBlock(
+            FixedGains(
+                start_sample=Fraction(10),
+                end_sample=Fraction(20),
+                gains=np.array([0.1]),
+            )
+        ),
+        DummyBlock(
+            FixedGains(
+                start_sample=Fraction(20),
+                end_sample=Fraction(30),
+                gains=np.array([0.2]),
+            )
+        ),
+        DummyBlock(
+            InterpGains(
+                start_sample=Fraction(40),
+                end_sample=Fraction(50),
+                gains_start=np.array([0.3]),
+                gains_end=np.array([0.3]),
+            )
+        ),
+    ]
+    expected_gains = np.repeat([0.0, 0.1, 0.2, 0.0, 0.3, 0.0], 10)
+    n_samples = 60
+    fs = 48000
+
+    num_interpret_calls = 0
+
+    def interpret(block_fs, block):
+        nonlocal num_interpret_calls
+        num_interpret_calls += 1
+
+        assert block_fs == fs
+
+        return [block.block]
+
+    channel = BlockProcessingChannel(MetadataSourceIter(blocks), interpret)
+
+    input_samples = 1.0 + np.random.random_sample(n_samples)
+    expected_output = (expected_gains * input_samples)[:, np.newaxis]
+
+    output_samples = np.zeros((n_samples, 1))
+    for start in range(0, n_samples, block_size):
+        end = start + block_size
+        channel.process(fs, start, input_samples[start:end], output_samples[start:end])
+
+    assert num_interpret_calls == 3
+    npt.assert_allclose(output_samples, expected_output)

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setup(
         'attrs~=19.3',
         'ruamel.yaml~=0.15',
         'lxml~=4.4',
-        'enum34~=1.1',
         'six~=1.11',
         'multipledispatch~=0.5',
     ],


### PR DESCRIPTION
Previously, `overlap()` would return a range with negative start/stop if
the sample block and the processing block did not overlap.
`BlockProcessingChannel` assumed that this case is a no-op, when it
actually caused indexing errors.