### PR TITLE
feature: add loudnessMetadata attributes and subelements as per BS.2076-1

### DIFF
--- a/ear/fileio/adm/elements/__init__.py
+++ b/ear/fileio/adm/elements/__init__.py
@@ -1,10 +1,11 @@
 # flake8: noqa
 from .main_elements import (AudioChannelFormat, AudioPackFormat, AudioTrackFormat,
-                            AudioStreamFormat, AudioProgramme, AudioContent, AudioObject, AudioTrackUID,
-                            FormatDefinition, TypeDefinition, Frequency)
+                            AudioStreamFormat, AudioProgramme, AudioContent,
+                            AudioObject, AudioTrackUID, FormatDefinition, TypeDefinition,
+                            Frequency, LoudnessMetadata)
 from .block_formats import (AudioBlockFormatObjects, ChannelLock, ObjectDivergence,
-                            JumpPosition, AudioBlockFormatDirectSpeakers, AudioBlockFormatBinaural, AudioBlockFormatHoa,
-                            AudioBlockFormatMatrix, MatrixCoefficient,
+                            JumpPosition, AudioBlockFormatDirectSpeakers, AudioBlockFormatBinaural, 
+                            AudioBlockFormatHoa, AudioBlockFormatMatrix, MatrixCoefficient,
                             CartesianZone, PolarZone)
 from .geom import (DirectSpeakerPolarPosition, DirectSpeakerCartesianPosition, BoundCoordinate,
                    ObjectPolarPosition, ObjectCartesianPosition, ScreenEdgeLock)

--- a/ear/fileio/adm/elements/main_elements.py
+++ b/ear/fileio/adm/elements/main_elements.py
@@ -36,6 +36,19 @@ class FormatDefinition(Enum):
 
 
 @attrs(slots=True)
+class LoudnessMetadata(object):
+    loudnessMethod = attrib(default=None, validator=optional(instance_of(string_types)))
+    loudnessRecType = attrib(default=None, validator=optional(instance_of(string_types)))
+    loudnessCorrectionType = attrib(default=None, validator=optional(instance_of(string_types)))
+    integratedLoudness = attrib(default=None, validator=optional(instance_of(float)))
+    loudnessRange = attrib(default=None, validator=optional(instance_of(float)))
+    maxTruePeak = attrib(default=None, validator=optional(instance_of(float)))
+    maxMomentary = attrib(default=None, validator=optional(instance_of(float)))
+    maxShortTerm = attrib(default=None, validator=optional(instance_of(float)))
+    dialogueLoudness = attrib(default=None, validator=optional(instance_of(float)))
+    
+
+@attrs(slots=True)
 class ADMElement(object):
     id = attrib(default=None)
     is_common_definition = attrib(default=False, validator=instance_of(bool))
@@ -61,6 +74,7 @@ class AudioProgramme(ADMElement):
 
     referenceScreen = attrib(validator=optional(instance_of((CartesianScreen, PolarScreen))),
                              default=default_screen)
+    loudnessMetadata = attrib(default=None, validator=optional(instance_of(LoudnessMetadata)))
 
     def lazy_lookup_references(self, adm):
         if self.audioContentIDRef is not None:
@@ -72,7 +86,7 @@ class AudioProgramme(ADMElement):
 class AudioContent(ADMElement):
     audioContentName = attrib(default=None, validator=instance_of(string_types))
     audioContentLanguage = attrib(default=None)
-    loudnessMetadata = attrib(default=None)
+    loudnessMetadata = attrib(default=None, validator=optional(instance_of(LoudnessMetadata)))
     dialogue = attrib(default=None)
     audioObjects = attrib(default=Factory(list), repr=False)
 

--- a/ear/fileio/adm/test/test_adm_files/base.xml
+++ b/ear/fileio/adm/test/test_adm_files/base.xml
@@ -5,9 +5,25 @@
             <audioFormatExtended>
                 <audioProgramme audioProgrammeID="APR_1001" audioProgrammeName="PanningNoise">
                     <audioContentIDRef>ACO_1001</audioContentIDRef>
+                    <loudnessMetadata loudnessMethod="ITU-R BS.1770" loudnessRecType="EBU R128" loudnessCorrectionType="file">
+                        <integratedLoudness>-24.0</integratedLoudness>
+                        <loudnessRange>12.5</loudnessRange>
+                        <maxTruePeak>-5.2</maxTruePeak>
+                        <maxMomentary>-9.9</maxMomentary>
+                        <maxShortTerm>-18.3</maxShortTerm>
+                        <dialogueLoudness>-10.2</dialogueLoudness>
+                    </loudnessMetadata>
                 </audioProgramme>
                 <audioContent audioContentID="ACO_1001" audioContentName="PanningNoise">
                     <audioObjectIDRef>AO_1001</audioObjectIDRef>
+                    <loudnessMetadata loudnessMethod="ITU-R BS.1770" loudnessRecType="EBU R128" loudnessCorrectionType="file">
+                        <integratedLoudness>-24.0</integratedLoudness>
+                        <loudnessRange>12.5</loudnessRange>
+                        <maxTruePeak>-5.2</maxTruePeak>
+                        <maxMomentary>-9.9</maxMomentary>
+                        <maxShortTerm>-18.3</maxShortTerm>
+                        <dialogueLoudness>-10.2</dialogueLoudness>
+                    </loudnessMetadata>
                 </audioContent>
                 <audioObject audioObjectID="AO_1001" audioObjectName="Noise" duration="00:00:12.00000" start="00:00:00.00000">
                     <audioPackFormatIDRef>AP_00031001</audioPackFormatIDRef>

--- a/ear/fileio/adm/test/test_xml.py
+++ b/ear/fileio/adm/test/test_xml.py
@@ -111,6 +111,24 @@ def get_acf(adm):
 
 bf_path = "//adm:audioBlockFormat"
 
+def test_loudness(base):
+    assert base.adm_after_mods().audioContents[0].loudnessMetadata.loudnessMethod == "ITU-R BS.1770"
+    assert base.adm_after_mods().audioContents[0].loudnessMetadata.loudnessRecType == "EBU R128"
+    assert base.adm_after_mods().audioContents[0].loudnessMetadata.loudnessCorrectionType == "file"
+    assert base.adm_after_mods().audioContents[0].loudnessMetadata.integratedLoudness == -24.0
+    assert base.adm_after_mods().audioContents[0].loudnessMetadata.loudnessRange == 12.5
+    assert base.adm_after_mods().audioContents[0].loudnessMetadata.maxTruePeak == -5.2
+    assert base.adm_after_mods().audioContents[0].loudnessMetadata.maxMomentary == -9.9
+    assert base.adm_after_mods().audioContents[0].loudnessMetadata.dialogueLoudness == -10.2
+
+    assert base.adm_after_mods().audioProgrammes[0].loudnessMetadata.loudnessMethod == "ITU-R BS.1770"
+    assert base.adm_after_mods().audioProgrammes[0].loudnessMetadata.loudnessRecType == "EBU R128"
+    assert base.adm_after_mods().audioProgrammes[0].loudnessMetadata.loudnessCorrectionType == "file"
+    assert base.adm_after_mods().audioProgrammes[0].loudnessMetadata.integratedLoudness == -24.0
+    assert base.adm_after_mods().audioProgrammes[0].loudnessMetadata.loudnessRange == 12.5
+    assert base.adm_after_mods().audioProgrammes[0].loudnessMetadata.maxTruePeak == -5.2
+    assert base.adm_after_mods().audioProgrammes[0].loudnessMetadata.maxMomentary == -9.9
+    assert base.adm_after_mods().audioProgrammes[0].loudnessMetadata.dialogueLoudness == -10.2   
 
 def test_gain(base):
     assert base.bf_after_mods(add_children(bf_path, E.gain("0"))).gain == 0.0

--- a/ear/fileio/adm/xml.py
+++ b/ear/fileio/adm/xml.py
@@ -14,7 +14,7 @@ from .elements import (
     ChannelLock, BoundCoordinate, JumpPosition, ObjectDivergence, CartesianZone, PolarZone, ScreenEdgeLock, MatrixCoefficient)
 from .elements import (
     AudioProgramme, AudioContent, AudioObject, AudioChannelFormat, AudioPackFormat, AudioStreamFormat, AudioTrackFormat, AudioTrackUID,
-    FormatDefinition, TypeDefinition, Frequency)
+    FormatDefinition, TypeDefinition, Frequency, LoudnessMetadata)
 from .elements.geom import (DirectSpeakerPolarPosition, DirectSpeakerCartesianPosition,
                             ObjectPolarPosition, ObjectCartesianPosition)
 from .time_format import parse_time, unparse_time
@@ -1033,6 +1033,19 @@ def make_audio_programme(referenceScreen=None, **kwargs):
     return AudioProgramme(referenceScreen=referenceScreen, **kwargs)
 
 
+
+loudness_handler = ElementParser(LoudnessMetadata, "loudnessMetadata", [
+    Attribute(adm_name="loudnessMethod", arg_name="loudnessMethod", type=StringType),
+    Attribute(adm_name="loudnessRecType", arg_name="loudnessRecType", type=StringType),
+    Attribute(adm_name="loudnessCorrectionType", arg_name="loudnessCorrectionType", type=StringType),
+    AttrElement(adm_name="integratedLoudness", arg_name="integratedLoudness", type=FloatType),
+    AttrElement(adm_name="loudnessRange", arg_name="loudnessRange", type=FloatType),
+    AttrElement(adm_name="maxTruePeak", arg_name="maxTruePeak", type=FloatType),
+    AttrElement(adm_name="maxMomentary", arg_name="maxMomentary", type=FloatType),
+    AttrElement(adm_name="maxShortTerm", arg_name="maxShortTerm", type=FloatType),
+    AttrElement(adm_name="dialogueLoudness", arg_name="dialogueLoudness", type=FloatType)
+])
+
 programme_handler = ElementParser(make_audio_programme, "audioProgramme", [
     Attribute(adm_name="audioProgrammeID", arg_name="id", required=True),
     Attribute(adm_name="audioProgrammeName", arg_name="audioProgrammeName", required=True),
@@ -1042,6 +1055,7 @@ programme_handler = ElementParser(make_audio_programme, "audioProgramme", [
     Attribute(adm_name="maxDuckingDepth", arg_name="maxDuckingDepth", type=FloatType),
     RefList("audioContent"),
     screen_handler.as_handler("referenceScreen", default=default_screen),
+    loudness_handler.as_handler("loudnessMetadata")
 ])
 
 content_handler = ElementParser(AudioContent, "audioContent", [
@@ -1050,6 +1064,7 @@ content_handler = ElementParser(AudioContent, "audioContent", [
     Attribute(adm_name="audioContentLanguage", arg_name="audioContentLanguage"),
     AttrElement(adm_name="dialogue", arg_name="dialogue", type=IntType),
     RefList("audioObject"),
+    loudness_handler.as_handler("loudnessMetadata")
 ])
 
 object_handler = ElementParser(AudioObject, "audioObject", [


### PR DESCRIPTION
This PR should enable loudnessMetadata as defined in **ITU-R BS.2076-1** for both audioContents and audioProgrammes. I noticed a discrepancy in BS.2076-1 regarding the spelling of "dialogueLoudness". The figures 16 and 17 spell it "dialogLoudness" whilst the text spells "dialogueLoudness". **ITU-R BS.2076-2** uses only "dialogueLoudness". So I oriented at the text rather than the figures. However, I'm not sure that this was the right interpretation since also the [ADM guidelines](https://adm.ebu.io/reference/adm_elements/loudness_metadata.html) refer to "dialogLoudness"...
I hope these additions are in line with the existing implementations and I also hope that the test(s) make sense the way I wrote it. Please let me know if this is not the case.
