### PR TITLE
raise errors for broken screens

### DIFF
--- a/ear/core/screen_common.py
+++ b/ear/core/screen_common.py
@@ -46,8 +46,16 @@ class PolarEdges(object):
         else:
             assert False
 
-        return cls(left_azimuth=azimuth(centre - x_vec),
-                   right_azimuth=azimuth(centre + x_vec),
+        left_azimuth = azimuth(centre - x_vec)
+        right_azimuth = azimuth(centre + x_vec)
+        if right_azimuth > left_azimuth:
+            raise ValueError("invalid screen specification: screen must not extend past -y")
+
+        if (azimuth(centre - z_vec) - azimuth(centre + z_vec)) > 1e-3:
+            raise ValueError("invalid screen specification: screen must not extend past +z or -z")
+
+        return cls(left_azimuth=left_azimuth,
+                   right_azimuth=right_azimuth,
                    bottom_elevation=elevation(centre - z_vec),
                    top_elevation=elevation(centre + z_vec))
 

--- a/ear/core/screen_scale.py
+++ b/ear/core/screen_scale.py
@@ -2,6 +2,7 @@ from .geom import azimuth, elevation, cart
 from .objectbased.conversion import point_cart_to_polar, point_polar_to_cart
 import numpy as np
 from .screen_common import PolarEdges, compensate_position
+from .util import interp_sorted
 
 
 class PolarScreenScaler(object):
@@ -17,12 +18,12 @@ class PolarScreenScaler(object):
         self.rep_screen_edges = PolarEdges.from_screen(reproduction_screen)
 
     def scale_az_el(self, az, el):
-        new_az = np.interp(az,
-                           (-180, self.ref_screen_edges.right_azimuth, self.ref_screen_edges.left_azimuth, 180),
-                           (-180, self.rep_screen_edges.right_azimuth, self.rep_screen_edges.left_azimuth, 180))
-        new_el = np.interp(el,
-                           (-90, self.ref_screen_edges.bottom_elevation, self.ref_screen_edges.top_elevation, 90),
-                           (-90, self.rep_screen_edges.bottom_elevation, self.rep_screen_edges.top_elevation, 90))
+        new_az = interp_sorted(az,
+                               (-180, self.ref_screen_edges.right_azimuth, self.ref_screen_edges.left_azimuth, 180),
+                               (-180, self.rep_screen_edges.right_azimuth, self.rep_screen_edges.left_azimuth, 180))
+        new_el = interp_sorted(el,
+                               (-90, self.ref_screen_edges.bottom_elevation, self.ref_screen_edges.top_elevation, 90),
+                               (-90, self.rep_screen_edges.bottom_elevation, self.rep_screen_edges.top_elevation, 90))
 
         return new_az, new_el
 

--- a/ear/core/test/test_screen_common.py
+++ b/ear/core/test/test_screen_common.py
@@ -1,5 +1,5 @@
 import numpy as np
-from pytest import approx
+from pytest import approx, raises
 from ..screen_common import PolarEdges, PolarScreen, CartesianScreen, compensate_position
 from ...common import default_screen, PolarPosition, CartesianPosition, cart, azimuth
 from ..objectbased.conversion import point_polar_to_cart
@@ -47,6 +47,38 @@ def test_polar_edges_from_polar_up():
     assert np.isclose(screen_edges.right_azimuth, azimuth(cart(0, 10, 1) + [np.tan(np.radians(58/2)), 0, 0]))
     assert np.isclose(screen_edges.top_elevation, default_edge_elevation + 10)
     assert np.isclose(screen_edges.bottom_elevation, -default_edge_elevation + 10)
+
+
+def test_polar_edge_error_az():
+    screen = PolarScreen(
+        aspectRatio=1.78,
+        centrePosition=PolarPosition(
+            azimuth=161.0,
+            elevation=0.0,
+            distance=1.0),
+        widthAzimuth=40.0)
+    expected = "invalid screen specification: screen must not extend past -y"
+    with raises(ValueError, match=expected):
+        PolarEdges.from_screen(screen)
+
+    screen.centrePosition.azimuth = 159.0
+    PolarEdges.from_screen(screen)
+
+
+def test_polar_edge_error_el():
+    screen = PolarScreen(
+        aspectRatio=1.0,
+        centrePosition=PolarPosition(
+            azimuth=30.0,
+            elevation=71.0,
+            distance=1.0),
+        widthAzimuth=40.0)
+    expected = "invalid screen specification: screen must not extend past \\+z or -z"
+    with raises(ValueError, match=expected):
+        PolarEdges.from_screen(screen)
+
+    screen.centrePosition.elevation = 69.0
+    PolarEdges.from_screen(screen)
 
 
 def test_polar_edges_from_cart_default():

--- a/ear/core/util.py
+++ b/ear/core/util.py
@@ -65,3 +65,10 @@ def safe_norm_position(position):
         return np.array([0.0, 1.0, 0.0])
     else:
         return position / norm
+
+
+def interp_sorted(x, xp, yp):
+    """same as np.interp, but checks that xp is sorted"""
+    xp = np.array(xp)
+    assert np.all(xp[:-1] <= xp[1:]), "unsorted xp values in call to interp"
+    return np.interp(x, xp, yp)


### PR DESCRIPTION
These are not directly in the spec, but if these errors are triggered then the behaviour existing behaviour didn't make sense anyway.