### PR TITLE
Fix mixed-up height and depth in conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased Changes
+
+### Fixed
+- Depth and height parameters were switched in metadata conversion. See [#26].
+
 ## [2.0.0] - 2019-05-22
 
 Changes for ITU ADM renderer reference code.
@@ -104,6 +109,7 @@ Changes for ITU ADM renderer reference code.
 
 Initial release.
 
+[#26]: https://github.com/ebu/ebu_adm_renderer/pull/26
 [2.0.0]: https://github.com/ebu/ebu_adm_renderer/compare/1.2.0...2.0.0
 [1.2.0]: https://github.com/ebu/ebu_adm_renderer/compare/1.1.2...1.2.0
 [1.1.2]: https://github.com/ebu/ebu_adm_renderer/compare/1.1.1...1.1.2

--- a/ear/core/objectbased/conversion.py
+++ b/ear/core/objectbased/conversion.py
@@ -14,8 +14,8 @@ def to_polar(block_format):
                                                       block_format.position.Y,
                                                       block_format.position.Z,
                                                       block_format.width,
-                                                      block_format.height,
-                                                      block_format.depth)
+                                                      block_format.depth,
+                                                      block_format.height)
 
         return evolve(block_format,
                       position=ObjectPolarPosition(azimuth, elevation, distance,
@@ -31,7 +31,7 @@ def to_cartesian(block_format):
         return block_format
     else:
         (X, Y, Z,
-         width, height, depth) = extent_polar_to_cart(block_format.position.azimuth,
+         width, depth, height) = extent_polar_to_cart(block_format.position.azimuth,
                                                       block_format.position.elevation,
                                                       block_format.position.distance,
                                                       block_format.width,

--- a/ear/core/objectbased/test/test_conversion.py
+++ b/ear/core/objectbased/test/test_conversion.py
@@ -61,23 +61,6 @@ def test_conversion_corners():
                     npt.assert_allclose(point_cart_to_polar(x*d, y*d, z*d),
                                         (az, el, d), atol=1e-10)
 
-def test_conversion_poles():
-    for sign in [-1, 1]:
-        for d in [0.5, 1, 2]:
-            npt.assert_allclose(point_polar_to_cart(0, sign * 90, d),
-                                [0.0, 0.0, sign * d], atol=1e-10)
-            npt.assert_allclose(point_cart_to_polar(0.0, 0.0, sign * d),
-                                (0, sign * 90, d), atol=1e-10)
-
-def test_conversion_centre():
-    for az in [-90, 0, 90]:
-        for el in [-90, 0, 90]:
-            npt.assert_allclose(point_polar_to_cart(az, el, 0.0),
-                                [0.0, 0.0, 0.0], atol=1e-10)
-
-    _az, _el, dist = point_cart_to_polar(0.0, 0.0, 0.0)
-    assert dist == approx(0.0)
-
 
 def test_conversion_poles():
     for sign in [-1, 1]:


### PR DESCRIPTION
The spec isn't explicit about how X, Y and Z size should map to width,
height and depth, but that is listed in table 16 of BS.2076-2, and this
way around is reasonably obvious.

Add some tests which check that the orientation looks correct in both
directions.

It might be worth revising the spec to make this clearer.