### PR TITLE
Fix channel lock priority order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 - Depth and height parameters were switched in metadata conversion. See [#26].
+- Bug in channel lock priority order, which controls the loudspeaker selection when the object position is the same distance from multiple loudspeakers. See [#28].
+
 
 ## [2.0.0] - 2019-05-22
 
@@ -110,6 +112,7 @@ Changes for ITU ADM renderer reference code.
 Initial release.
 
 [#26]: https://github.com/ebu/ebu_adm_renderer/pull/26
+[#28]: https://github.com/ebu/ebu_adm_renderer/pull/28
 [2.0.0]: https://github.com/ebu/ebu_adm_renderer/compare/1.2.0...2.0.0
 [1.2.0]: https://github.com/ebu/ebu_adm_renderer/compare/1.1.2...1.2.0
 [1.1.2]: https://github.com/ebu/ebu_adm_renderer/compare/1.1.1...1.1.2

--- a/ear/core/objectbased/gain_calc.py
+++ b/ear/core/objectbased/gain_calc.py
@@ -45,7 +45,9 @@ class ChannelLockHandlerBase(object):
         # ties broken by elevation, absolute azimuth then azimuth.
         priority_order = np.lexsort((azimuths, np.abs(azimuths),
                                      elevations, np.abs(elevations)))
-        self.channel_priority = np.arange(len(layout.channels))[priority_order]
+
+        self.channel_priority = np.zeros(len(layout.channels), dtype=int)
+        self.channel_priority[priority_order] = np.arange(len(layout.channels))
 
     def handle(self, position, channelLock, excluded=None):
         """Apply channel lock to a position.

--- a/ear/core/objectbased/test/test_channel_lock.py
+++ b/ear/core/objectbased/test/test_channel_lock.py
@@ -1,0 +1,38 @@
+from ..gain_calc import EgoChannelLockHandler
+from ... import bs2051
+
+
+def test_priority():
+    """check that the channel lock priority order is sensible"""
+    layout = bs2051.get_layout("9+10+3").without_lfe
+    handler = EgoChannelLockHandler(layout)
+
+    priority_order = [
+        "M+000",
+        "M-030",
+        "M+030",
+        "M-060",
+        "M+060",
+        "M-090",
+        "M+090",
+        "M-135",
+        "M+135",
+        "M+180",
+        "B+000",
+        "B-045",
+        "B+045",
+        "U+000",
+        "U-045",
+        "U+045",
+        "U-090",
+        "U+090",
+        "U-135",
+        "U+135",
+        "U+180",
+        "T+000",
+    ]
+
+    for i, (name, priority) in enumerate(
+        zip(layout.channel_names, handler.channel_priority)
+    ):
+        assert priority_order.index(name) == priority

--- a/ear/core/objectbased/test/test_gain_calc.py
+++ b/ear/core/objectbased/test/test_gain_calc.py
@@ -194,6 +194,16 @@ def test_channel_lock_no_max_exclude(layout, gain_calc):
              direct_gains=[("M-030", 1.0)])
 
 
+def test_channel_lock_centre_cart():
+    layout = bs2051.get_layout("9+10+3").without_lfe
+    gain_calc = GainCalc(layout)
+    run_test(layout, gain_calc,
+             dict(channelLock=ChannelLock(),
+                  cartesian=True,
+                  position=dict(X=0.0, Y=0.0, Z=0.0)),
+             direct_gains=[("M-090", 1.0)])
+
+
 def test_diverge_half(layout, gain_calc):
     run_test(layout, gain_calc,
              dict(position=dict(azimuth=0.0, elevation=0.0, distance=1.0),


### PR DESCRIPTION
The intent of this line was to produce a vector containing the index of each number in priority_order:

```python
np.arange(len(layout.channels))[priority_order]
```

but this does nothing; the result is the same as priority_order.

In this case the spec and the original intent was correct, see section 7.3.6; this behaviour makes no sense. The existing tests aren't too bad, it just looks like we were unlucky and didn't hit any cases which were incorrect.

This is quite unlikely to have happened in the real world; the result would have been that if the position was exactly between 2 channels, the 'wrong' one may have been picked, resulting in left-right inconsistency, for example.