### PR TITLE
Tidy warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
     - `interpolationTime` parameter larger than `duration`.
     - `audioBlockFormat` `rtime` plus `duration` extending past the end of the containing `audioObject`.
 - Issue a warning for `DirectSpeakers` blocks with a `speakerLabel` containing `LFE` which is not detected as an LFE channel. See [#9].
+- Improved warning and error output: tidier formatting, and repeated warnings are suppressed by default. See [#37].
 
 ### Added
 - `loudnessMetadata` data structures, parsing and generation. See [#25].
@@ -136,6 +137,7 @@ Initial release.
 [#25]: https://github.com/ebu/ebu_adm_renderer/pull/25
 [#26]: https://github.com/ebu/ebu_adm_renderer/pull/26
 [#28]: https://github.com/ebu/ebu_adm_renderer/pull/28
+[#37]: https://github.com/ebu/ebu_adm_renderer/pull/37
 [34b738a]: https://github.com/ebu/ebu_adm_renderer/commit/34b738a
 [04533fc]: https://github.com/ebu/ebu_adm_renderer/commit/04533fc
 [222374a]: https://github.com/ebu/ebu_adm_renderer/commit/222374a

--- a/ear/cmdline/error_handler.py
+++ b/ear/cmdline/error_handler.py
@@ -15,8 +15,21 @@ def error_handler(logger: logging.Logger, debug: bool = False, strict: bool = Fa
         debug: should we be more verbose, printing full exceptions
         strict: turn unknown attribute warnings into errors
     """
+    if debug:
+
+        def showwarning(message, category, filename, lineno, file=None, line=None):
+            category = category.__name__
+            msg = f"{filename}:{lineno}: {category}: {message}"
+            logger.warning(msg)
+
+    else:
+
+        def showwarning(message, category, filename, lineno, file=None, line=None):
+            logger.warning(message)
+
     try:
         with warnings.catch_warnings():
+            warnings.showwarning = showwarning  # documentation says this is allowed
             if strict:
                 warnings.filterwarnings("error", category=AdmUnknownAttribute)
             yield

--- a/ear/cmdline/error_handler.py
+++ b/ear/cmdline/error_handler.py
@@ -1,0 +1,28 @@
+import contextlib
+import logging
+import sys
+import warnings
+from ..fileio.adm.exceptions import AdmUnknownAttribute
+
+
+@contextlib.contextmanager
+def error_handler(logger: logging.Logger, debug: bool = False, strict: bool = False):
+    """Context manager for use in CLIs which handles logging of exceptions and
+    warnings.
+
+    Parameters:
+        logger: log to write to
+        debug: should we be more verbose, printing full exceptions
+        strict: turn unknown attribute warnings into errors
+    """
+    try:
+        with warnings.catch_warnings():
+            if strict:
+                warnings.filterwarnings("error", category=AdmUnknownAttribute)
+            yield
+    except Exception as error:
+        if debug:
+            raise
+        else:
+            logger.error(error)
+            sys.exit(1)

--- a/ear/cmdline/utils.py
+++ b/ear/cmdline/utils.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import argparse
+import logging
 import sys
 from ..compatibility import write_bytes_to_stdout
 from ..fileio import openBw64, openBw64Adm
@@ -7,6 +8,11 @@ from ..fileio.bw64.chunks import FormatInfoChunk, ChnaChunk
 import warnings
 from . import ambix_to_bwf
 from . import generate_test_file
+from .error_handler import error_handler
+
+
+logging.basicConfig()
+logger = logging.getLogger("ear")
 
 
 def replace_axml_command(args):
@@ -90,6 +96,10 @@ def make_parser():
     parser = argparse.ArgumentParser(description='EBU ADM renderer utilities')
     subparsers = parser.add_subparsers(title='available subcommands')
 
+    parser.add_argument("-d", "--debug",
+                        help="print debug information when an error occurs",
+                        action="store_true")
+
     def add_replace_axml_command():
         subparser = subparsers.add_parser("replace_axml", help="replace the axml chunk in an existing ADM BWF file")
         subparser.add_argument("input", help="input bwf file")
@@ -139,7 +149,8 @@ def parse_command_line():
 def main():
     args = parse_command_line()
 
-    args.command(args)
+    with error_handler(logger, debug=args.debug):
+        args.command(args)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- feed everything through logger for consistent output
- only print warning message by default, and always suppress the actual line, which is never useful 
- add common utility for handling errors / warnings
- suppress repeated warnings (after 5 copies)