### PR TITLE
adm builder: multi-channel item creation and split format from content

### DIFF
--- a/ear/cmdline/ambix_to_bwf.py
+++ b/ear/cmdline/ambix_to_bwf.py
@@ -2,8 +2,19 @@ import numpy as np
 import lxml.etree
 from ..core.hoa import from_acn
 from ..fileio.adm.adm import ADM
-from ..fileio.adm.elements import AudioBlockFormatHoa, AudioChannelFormat, TypeDefinition, FormatDefinition
-from ..fileio.adm.elements import AudioStreamFormat, AudioTrackFormat, AudioPackFormat, AudioObject, AudioTrackUID
+from ..fileio.adm.elements import (
+    AudioBlockFormatHoa,
+    AudioChannelFormat,
+    TypeDefinition,
+    FormatDefinition,
+)
+from ..fileio.adm.elements import (
+    AudioStreamFormat,
+    AudioTrackFormat,
+    AudioPackFormat,
+    AudioObject,
+    AudioTrackUID,
+)
 from ..fileio.adm.chna import populate_chna_chunk
 from ..fileio.adm.generate_ids import generate_ids
 from ..fileio.adm.xml import adm_to_xml
@@ -12,11 +23,20 @@ from ..fileio.bw64.chunks import ChnaChunk, FormatInfoChunk
 
 
 def add_args(subparsers):
-    subparser = subparsers.add_parser("ambix_to_bwf", help="make a BWF file from an ambix format HOA file")
+    subparser = subparsers.add_parser(
+        "ambix_to_bwf", help="make a BWF file from an ambix format HOA file"
+    )
     subparser.add_argument("--norm", default="SN3D", help="normalization mode")
-    subparser.add_argument("--nfcDist", type=float, default=None, help="Near-Field Compensation Distance (float)")
+    subparser.add_argument(
+        "--nfcDist",
+        type=float,
+        default=None,
+        help="Near-Field Compensation Distance (float)",
+    )
     subparser.add_argument("--screenRef", help="Screen Reference", action="store_true")
-    subparser.add_argument("--chna-only", help="use only CHNA with common definitions", action="store_true")
+    subparser.add_argument(
+        "--chna-only", help="use only CHNA with common definitions", action="store_true"
+    )
     subparser.add_argument("input", help="input file")
     subparser.add_argument("output", help="output BWF file")
     subparser.set_defaults(command=ambix_to_bwf)
@@ -91,23 +111,30 @@ def build_adm(acn, norm, nfcDist, screenRef):
 
 def build_adm_common_defs(acns, norm):
     from ..fileio.adm.common_definitions import load_common_definitions
+
     adm = ADM()
     load_common_definitions(adm)
 
     order, degree = from_acn(acns)
 
     pack_name = "3D_order{order}_{norm}_ACN".format(order=max(order), norm=norm)
-    [pack_format] = [apf for apf in adm.audioPackFormats if apf.audioPackFormatName == pack_name]
+    [pack_format] = [
+        apf for apf in adm.audioPackFormats if apf.audioPackFormatName == pack_name
+    ]
 
     for channel_no, acn in enumerate(acns, 1):
         track_name = "PCM_{norm}_ACN_{acn}".format(norm=norm, acn=acn)
-        [track_format] = [tf for tf in adm.audioTrackFormats if tf.audioTrackFormatName == track_name]
+        [track_format] = [
+            tf for tf in adm.audioTrackFormats if tf.audioTrackFormatName == track_name
+        ]
 
-        adm.addAudioTrackUID(AudioTrackUID(
-            trackIndex=channel_no,
-            audioTrackFormat=track_format,
-            audioPackFormat=pack_format,
-        ))
+        adm.addAudioTrackUID(
+            AudioTrackUID(
+                trackIndex=channel_no,
+                audioTrackFormat=track_format,
+                audioPackFormat=pack_format,
+            )
+        )
 
     return adm
 
@@ -134,13 +161,18 @@ def ambix_to_bwf(args):
         chna = ChnaChunk()
         populate_chna_chunk(chna, adm)
 
-        fmtInfo = FormatInfoChunk(formatTag=1,
-                                  channelCount=infile.channels,
-                                  sampleRate=infile.sampleRate,
-                                  bitsPerSample=infile.bitdepth)
+        fmtInfo = FormatInfoChunk(
+            formatTag=1,
+            channelCount=infile.channels,
+            sampleRate=infile.sampleRate,
+            bitsPerSample=infile.bitdepth,
+        )
 
-        with openBw64(args.output, 'w', chna=chna, formatInfo=fmtInfo, axml=axml) as outfile:
+        with openBw64(
+            args.output, "w", chna=chna, formatInfo=fmtInfo, axml=axml
+        ) as outfile:
             while True:
                 samples = infile.read(1024)
-                if samples.shape[0] == 0: break
+                if samples.shape[0] == 0:
+                    break
                 outfile.write(samples)

--- a/ear/fileio/adm/builder.py
+++ b/ear/fileio/adm/builder.py
@@ -89,7 +89,7 @@ class ADMBuilder(object):
         """Create a new audioProgramme.
 
         Args:
-            kwargs: see :class:`AudioProgramme`
+            kwargs: see :class:`.AudioProgramme`
 
         Returns:
             AudioProgramme: created audioProgramme
@@ -106,7 +106,7 @@ class ADMBuilder(object):
 
         Args:
             parent (AudioProgramme): parent programme; defaults to the last one created
-            kwargs: see :class:`AudioContent`
+            kwargs: see :class:`.AudioContent`
 
         Returns:
             AudioContent: created audioContent
@@ -130,7 +130,7 @@ class ADMBuilder(object):
         Args:
             parent (Union[AudioContent, AudioObject]): parent content or
                 object; defaults to the last content created
-            kwargs: see :class:`AudioObject`
+            kwargs: see :class:`.AudioObject`
 
         Returns:
             AudioObject: created audioObject
@@ -154,7 +154,7 @@ class ADMBuilder(object):
         Args:
             parent (AudioObject or AudioPackFormat): parent object or packFormat;
                 defaults to the last object created
-            kwargs: see :class:`AudioPackFormat`
+            kwargs: see :class:`.AudioPackFormat`
 
         Returns:
             AudioPackFormat: created audioPackFormat
@@ -177,7 +177,7 @@ class ADMBuilder(object):
         Args:
             parent (AudioPackFormat): parent packFormat;
                 defaults to the last packFormat created
-            kwargs: see :class:`AudioChannelFormat`
+            kwargs: see :class:`.AudioChannelFormat`
 
         Returns:
             AudioChannelFormat: created audioChannelFormat

--- a/ear/fileio/adm/builder.py
+++ b/ear/fileio/adm/builder.py
@@ -8,6 +8,7 @@ from .elements import (
     AudioTrackFormat,
     AudioTrackUID,
     AudioStreamFormat,
+    AudioBlockFormatHoa,
 )
 
 
@@ -17,6 +18,34 @@ class _Default(object):
 
 
 DEFAULT = _Default()
+
+
+def _make_format_property(attribute):
+    """Make a property which forwards gets/sets to format.attribute."""
+
+    def getter(self):
+        return getattr(self.format, attribute)
+
+    def setter(self, new_val):
+        return setattr(self.format, attribute, new_val)
+
+    return property(getter, setter, doc=f"accessor for format.{attribute}")
+
+
+def _make_singlar_property(attribute, attribute_singular):
+    """Make a property which forwards gets/sets to attribute, assuming it is a
+    list with a single entry.
+    """
+
+    def getter(self):
+        items = getattr(self, attribute)
+        assert len(items) == 1, f"expected 1 {attribute_singular}, got {len(items)}"
+        return items[0]
+
+    def setter(self, new_val):
+        return setattr(self, attribute, [new_val])
+
+    return property(getter, setter, doc=f"singular accessor for {attribute}")
 
 
 @attrs
@@ -222,32 +251,149 @@ class ADMBuilder(object):
         return track_uid
 
     @attrs
-    class MonoItem(object):
-        """Structure referencing the ADM components created as part of a mono item.
+    class Format(object):
+        """Structure referencing the ADM components of a format with a
+        particular channel layout.
+
+        This holds an audioPackFormat, and one audioTrackFormat,
+        audioStreamFormat and audioChannelFormat per channel in the format.
 
         Attributes:
-            channel_format (AudioChannelFormat)
-            track_format (AudioTrackFormat)
+            channel_formats (list[AudioChannelFormat])
+            track_formats (list[AudioTrackFormat])
             pack_format (AudioPackFormat)
-            stream_format (AudioStreamFormat)
-            track_uid (AudioTrackUID)
+            stream_formats (list[AudioStreamFormat])
+        """
+
+        channel_formats = attrib()
+        track_formats = attrib()
+        pack_format = attrib()
+        stream_formats = attrib()
+
+        channel_format = _make_singlar_property("channel_formats", "channel_format")
+        track_format = _make_singlar_property("track_formats", "track_format")
+        stream_format = _make_singlar_property("stream_formats", "stream_format")
+
+    @attrs
+    class Item(object):
+        """Structure referencing the ADM components of a created item.
+
+        This holds an audioObject, one audioTrackUID per channel, and a
+        reference to :class:`Format` for the format parts of the item.
+
+        Attributes:
+            format (Format)
+            track_uids (list[AudioTrackUID])
             audio_object (AudioObject)
             parent (Union[AudioContent, AudioObject])
         """
 
-        channel_format = attrib()
-        track_format = attrib()
-        pack_format = attrib()
-        stream_format = attrib()
-        track_uid = attrib()
+        format = attrib()
+        track_uids = attrib()
         audio_object = attrib()
         parent = attrib()
+
+        track_uid = _make_singlar_property("track_uids", "track_uid")
+
+        channel_formats = _make_format_property("channel_formats")
+        track_formats = _make_format_property("track_formats")
+        pack_format = _make_format_property("pack_format")
+        stream_formats = _make_format_property("stream_formats")
+
+        channel_format = _make_format_property("channel_format")
+        track_format = _make_format_property("track_format")
+        stream_format = _make_format_property("stream_format")
+
+    MonoItem = Item
+    """compatibility alias for users expecting \\*_mono to return MonoItem"""
+
+    def create_format_mono(
+        self,
+        type,
+        name,
+        block_formats=[],
+    ):
+        """Create ADM components needed to represent a mono format.
+
+        This makes:
+
+        - an audioChannelFormat with the given block_formats
+        - an audioPackFormat linked to the audioChannelFormat
+        - an audioStreamFormat linked to the audioChannelFormat
+        - an audioTrackFormat linked to the audioStreamFormat
+
+        Args:
+            type (TypeDefinition): type of channelFormat and packFormat
+            name (str): name used for all components
+            block_formats (list[AudioBlockFormat]): block formats to add to
+                the channel format
+
+        Returns:
+            Format: the created components
+        """
+        format = self.create_format_multichannel(
+            type=type,
+            name=name,
+            block_formats=[block_formats],
+        )
+
+        self.last_pack_format = format.pack_format
+        self.last_stream_format = format.stream_format
+
+        return format
+
+    def create_item_mono_from_format(
+        self,
+        format,
+        track_index,
+        name,
+        parent=DEFAULT,
+    ):
+        """Create ADM components needed to represent a mono channel given an
+        existing format.
+
+        This makes:
+
+        - an audioTrackUID linked to the audioTrackFormat and audioPackFormat
+          of format
+        - an audioObject linked to the audioTrackUID and audioPackFormat
+
+        Args:
+            format (Format)
+            track_index (int): zero-based index of the track in the BWF file.
+            name (str): name used for all components
+            parent (Union[AudioContent, AudioObject]): parent of the created audioObject
+                defaults to the last content or explicitly created object
+
+        Returns:
+            Item: the created components
+        """
+        item = self.create_item_multichannel_from_format(
+            format=format,
+            track_indices=[track_index],
+            name=name,
+            parent=parent,
+        )
+
+        self.last_pack_format = item.pack_format
+        self.last_stream_format = item.stream_format
+
+        return item
 
     def create_item_mono(
         self, type, track_index, name, parent=DEFAULT, block_formats=[]
     ):
         """Create ADM components needed to represent a mono channel, either
         DirectSpeakers or Objects.
+
+        This makes:
+
+        - an audioChannelFormat with the given block_formats
+        - an audioPackFormat linked to the audioChannelFormat
+        - an audioStreamFormat linked to the audioChannelFormat
+        - an audioTrackFormat linked to the audioStreamFormat
+        - an audioTrackUID linked to the audioTrackFormat and audioPackFormat
+        - an audioObject linked to the audioTrackUID and audioPackFormat
 
         Args:
             type (TypeDefinition): type of channelFormat and packFormat
@@ -259,45 +405,152 @@ class ADMBuilder(object):
                 the channel format
 
         Returns:
-            MonoItem: the created components
+            Item: the created components
         """
-        channel_format = AudioChannelFormat(
-            audioChannelFormatName=name, type=type, audioBlockFormats=block_formats
+        item = self.create_item_multichannel(
+            type=type,
+            track_indices=[track_index],
+            name=name,
+            block_formats=[block_formats],
+            parent=parent,
         )
-        self.adm.addAudioChannelFormat(channel_format)
+
+        self.last_pack_format = item.pack_format
+        self.last_stream_format = item.stream_format
+
+        return item
+
+    def create_item_objects(self, *args, **kwargs):
+        """Create ADM components needed to represent an object channel.
+
+        Wraps :func:`create_item_mono` with ``type=TypeDefinition.Objects``.
+
+        Returns:
+            Item: the created components
+        """
+        return self.create_item_mono(TypeDefinition.Objects, *args, **kwargs)
+
+    def create_item_direct_speakers(self, *args, **kwargs):
+        """Create ADM components needed to represent a DirectSpeakers channel.
+
+        Wraps :func:`create_item_mono` with ``type=TypeDefinition.DirectSpeakers``.
+
+        Returns:
+            Item: the created components
+        """
+        return self.create_item_mono(TypeDefinition.DirectSpeakers, *args, **kwargs)
+
+    def create_format_multichannel(self, type, name, block_formats):
+        """Create ADM components representing a multi-channel format.
+
+        This makes:
+
+        - an audioChannelFormat for each channel
+        - an audioStreamFormat linked to each audioChannelFormat
+        - an audioTrackFormat linked to each audioStreamFormat
+        - an audioPackFormat linked to the audioChannelFormats
+
+        Args:
+            type (TypeDefinition): type of channelFormat and packFormat
+            name (str): name used for all components
+            block_formats (list[list[AudioBlockFormat]]): list of audioBlockFormats
+                for each audioChannelFormat
+
+        Returns:
+            Format: the created components
+        """
+        channel_formats = []
+        stream_formats = []
+        track_formats = []
+
+        for i, channel_block_formats in enumerate(block_formats):
+            channel_name = f"{name}_{i + 1}" if len(block_formats) > 1 else name
+
+            channel_format = AudioChannelFormat(
+                audioChannelFormatName=channel_name,
+                type=type,
+                audioBlockFormats=channel_block_formats,
+            )
+            self.adm.addAudioChannelFormat(channel_format)
+            channel_formats.append(channel_format)
+
+            stream_format = AudioStreamFormat(
+                audioStreamFormatName=channel_name,
+                format=FormatDefinition.PCM,
+                audioChannelFormat=channel_format,
+            )
+            self.adm.addAudioStreamFormat(stream_format)
+            stream_formats.append(stream_format)
+
+            track_format = AudioTrackFormat(
+                audioTrackFormatName=channel_name,
+                audioStreamFormat=stream_format,
+                format=FormatDefinition.PCM,
+            )
+            self.adm.addAudioTrackFormat(track_format)
+            track_formats.append(track_format)
 
         pack_format = AudioPackFormat(
             audioPackFormatName=name,
             type=type,
-            audioChannelFormats=[channel_format],
+            audioChannelFormats=channel_formats[:],
         )
         self.adm.addAudioPackFormat(pack_format)
 
-        stream_format = AudioStreamFormat(
-            audioStreamFormatName=name,
-            format=FormatDefinition.PCM,
-            audioChannelFormat=channel_format,
+        return self.Format(
+            channel_formats=channel_formats,
+            track_formats=track_formats,
+            pack_format=pack_format,
+            stream_formats=stream_formats,
         )
-        self.adm.addAudioStreamFormat(stream_format)
 
-        track_format = AudioTrackFormat(
-            audioTrackFormatName=name,
-            audioStreamFormat=stream_format,
-            format=FormatDefinition.PCM,
-        )
-        self.adm.addAudioTrackFormat(track_format)
+    def create_item_multichannel_from_format(
+        self,
+        format,
+        track_indices,
+        name,
+        parent=DEFAULT,
+    ):
+        """Create ADM components representing a multi-channel object,
+        referencing an existing format structure.
 
-        track_uid = AudioTrackUID(
-            trackIndex=track_index + 1,
-            audioTrackFormat=track_format,
-            audioPackFormat=pack_format,
-        )
-        self.adm.addAudioTrackUID(track_uid)
+        This makes:
+
+        - an audioTrackUID linked to each audioTrackFormat and the audioPackFormat in format
+        - an audioObject linked to the audioTrackUIDs and the audioPackFormat in format
+
+        Args:
+            format (Format): format components to reference
+            track_indices (list[int]): zero-based indices of the tracks in the BWF file.
+            name (str): name used for all components
+            parent (Union[AudioContent, AudioObject]): parent of the created audioObject
+                defaults to the last content or explicitly created object
+
+        Returns:
+            Item: the created components
+        """
+        if len(track_indices) != len(format.track_formats):
+            raise ValueError(
+                "track_indices and format must have the same number of channels"
+            )
+
+        track_uids = []
+
+        for i, (track_index, track_format) in enumerate(
+            zip(track_indices, format.track_formats)
+        ):
+            track_uid = AudioTrackUID(
+                trackIndex=track_index + 1,
+                audioTrackFormat=track_format,
+                audioPackFormat=format.pack_format,
+            )
+            self.adm.addAudioTrackUID(track_uid)
+            track_uids.append(track_uid)
 
         audio_object = AudioObject(
             audioObjectName=name,
-            audioPackFormats=[pack_format],
-            audioTrackUIDs=[track_uid],
+            audioPackFormats=[format.pack_format],
+            audioTrackUIDs=track_uids[:],
         )
         self.adm.addAudioObject(audio_object)
 
@@ -307,29 +560,135 @@ class ADMBuilder(object):
             parent.audioObjects.append(audio_object)
 
         self.last_object = audio_object
-        self.last_pack_format = pack_format
-        self.last_stream_format = stream_format
+        self.last_pack_format = format.pack_format
 
-        return self.MonoItem(
-            channel_format=channel_format,
-            track_format=track_format,
-            pack_format=pack_format,
-            stream_format=stream_format,
-            track_uid=track_uid,
+        return self.Item(
+            format=format,
+            track_uids=track_uids,
             audio_object=audio_object,
             parent=parent,
         )
 
-    def create_item_objects(self, *args, **kwargs):
-        """Create ADM components needed to represent an object channel.
+    def create_item_multichannel(
+        self,
+        type,
+        track_indices,
+        name,
+        block_formats,
+        parent=DEFAULT,
+    ):
+        """Create ADM components representing a multi-channel object.
 
-        Wraps :func:`create_item_mono` with ``type=TypeDefinition.Objects``.
+        This makes:
+
+        - an audioChannelFormat for each channel
+        - an audioStreamFormat linked to each audioChannelFormat
+        - an audioTrackFormat linked to each audioStreamFormat
+        - an audioPackFormat linked to the audioChannelFormats
+        - an audioTrackUID linked to each audioTrackFormat and the audioPackFormat
+        - an audioObject linked to the audioTrackUIDs and the audioPackFormat
+
+        Args:
+            type (TypeDefinition): type of channelFormat and packFormat
+            track_indices (list[int]): zero-based indices of the tracks in the BWF file.
+            name (str): name used for all components
+            block_formats (list[list[AudioBlockFormat]]): list of audioBlockFormats
+                for each audioChannelFormat
+            parent (Union[AudioContent, AudioObject]): parent of the created audioObject
+                defaults to the last content or explicitly created object
+
+        Returns:
+            Item: the created components
         """
-        return self.create_item_mono(TypeDefinition.Objects, *args, **kwargs)
+        if len(track_indices) != len(block_formats):
+            raise ValueError("track_indices and block_formats must be the same length")
 
-    def create_item_direct_speakers(self, *args, **kwargs):
-        """Create ADM components needed to represent a DirectSpeakers channel.
+        format = self.create_format_multichannel(
+            type=type,
+            name=name,
+            block_formats=block_formats,
+        )
 
-        Wraps :func:`create_item_mono` with ``type=TypeDefinition.DirectSpeakers``.
+        return self.create_item_multichannel_from_format(
+            format=format,
+            track_indices=track_indices,
+            name=name,
+            parent=parent,
+        )
+
+    def create_format_hoa(
+        self,
+        orders,
+        degrees,
+        name,
+        **kwargs,
+    ):
+        """Create ADM components representing the format of a HOA stream.
+
+        This is a wrapper around :func:`create_format_multichannel`.
+
+        Args:
+            orders (list[int]): order for each track
+            degrees (list[int]): degree for each track
+            name (str): name used for all components
+            kwargs: arguments for :class:`.AudioBlockFormatHoa`
+
+        Returns:
+            Format: the created components
         """
-        return self.create_item_mono(TypeDefinition.DirectSpeakers, *args, **kwargs)
+        block_formats = [
+            [
+                AudioBlockFormatHoa(
+                    order=order,
+                    degree=degree,
+                    **kwargs,
+                )
+            ]
+            for order, degree in zip(orders, degrees)
+        ]
+
+        return self.create_format_multichannel(
+            type=TypeDefinition.HOA,
+            name=name,
+            block_formats=block_formats,
+        )
+
+    def create_item_hoa(
+        self,
+        track_indices,
+        orders,
+        degrees,
+        name,
+        parent=DEFAULT,
+        **kwargs,
+    ):
+        """Create ADM components representing a HOA stream.
+
+        This is a wrapper around :func:`create_format_hoa` and
+        :func:`create_item_multichannel_from_format`.
+
+        Args:
+            track_indices (list[int]): zero-based indices of the tracks in the BWF file.
+            orders (list[int]): order for each track
+            degrees (list[int]): degree for each track
+            name (str): name used for all components
+            parent (Union[AudioContent, AudioObject]): parent of the created audioObject
+                defaults to the last content or explicitly created object
+            kwargs: arguments for :class:`.AudioBlockFormatHoa`
+
+        Returns:
+            Item: the created components
+        """
+        format = self.create_format_hoa(
+            orders=orders,
+            degrees=degrees,
+            name=name,
+            **kwargs,
+        )
+
+        return self.create_item_multichannel_from_format(
+            format=format,
+            track_indices=track_indices,
+            name=name,
+            parent=parent,
+        )

--- a/ear/fileio/adm/builder.py
+++ b/ear/fileio/adm/builder.py
@@ -2,7 +2,13 @@ from attr import attrs, attrib, Factory
 from .adm import ADM
 from .elements import AudioProgramme, AudioContent, AudioObject
 from .elements import TypeDefinition, FormatDefinition
-from .elements import AudioChannelFormat, AudioPackFormat, AudioTrackFormat, AudioTrackUID, AudioStreamFormat
+from .elements import (
+    AudioChannelFormat,
+    AudioPackFormat,
+    AudioTrackFormat,
+    AudioTrackUID,
+    AudioStreamFormat,
+)
 
 
 class _Default(object):
@@ -35,6 +41,7 @@ class ADMBuilder(object):
             explicitly created audioContent or audioObject, used as the parent
             for audioObjects created by create_item* functions.
     """
+
     adm = attrib(default=Factory(ADM))
     last_programme = attrib(default=None)
     last_content = attrib(default=None)
@@ -46,6 +53,7 @@ class ADMBuilder(object):
     def load_common_definitions(self):
         """Load common definitions into adm."""
         from .common_definitions import load_common_definitions
+
         load_common_definitions(self.adm)
 
     def create_programme(self, **kwargs):
@@ -235,7 +243,9 @@ class ADMBuilder(object):
         audio_object = attrib()
         parent = attrib()
 
-    def create_item_mono(self, type, track_index, name, parent=DEFAULT, block_formats=[]):
+    def create_item_mono(
+        self, type, track_index, name, parent=DEFAULT, block_formats=[]
+    ):
         """Create ADM components needed to represent a mono channel, either
         DirectSpeakers or Objects.
 
@@ -252,9 +262,8 @@ class ADMBuilder(object):
             MonoItem: the created components
         """
         channel_format = AudioChannelFormat(
-            audioChannelFormatName=name,
-            type=type,
-            audioBlockFormats=block_formats)
+            audioChannelFormatName=name, type=type, audioBlockFormats=block_formats
+        )
         self.adm.addAudioChannelFormat(channel_format)
 
         pack_format = AudioPackFormat(

--- a/ear/fileio/adm/test/test_builder.py
+++ b/ear/fileio/adm/test/test_builder.py
@@ -1,0 +1,102 @@
+import pytest
+from ..builder import ADMBuilder
+from ..elements import (
+    AudioBlockFormatHoa,
+    AudioBlockFormatObjects,
+    ObjectPolarPosition,
+    TypeDefinition,
+)
+
+
+@pytest.mark.parametrize("use_wrapper", [False, True])
+def test_hoa(use_wrapper):
+    builder = ADMBuilder()
+
+    programme = builder.create_programme(audioProgrammeName="programme")
+    content = builder.create_content(audioContentName="content")
+
+    normalization = "SN3D"
+    orders = [0, 1, 1, 1]
+    degrees = [0, -1, 0, 1]
+
+    blocks = [
+        [AudioBlockFormatHoa(order=order, degree=degree, normalization=normalization)]
+        for order, degree in zip(orders, degrees)
+    ]
+    track_indices = list(range(len(blocks)))
+
+    if use_wrapper:
+        item = builder.create_item_multichannel(
+            type=TypeDefinition.HOA,
+            track_indices=track_indices,
+            name="myitem",
+            block_formats=blocks,
+        )
+    else:
+        item = builder.create_item_hoa(
+            track_indices=track_indices,
+            name="myitem",
+            orders=orders,
+            degrees=degrees,
+            normalization=normalization,
+        )
+
+    for i in range(len(blocks)):
+        track_index = track_indices[i]
+        channel_blocks = blocks[i]
+        track_format = item.track_formats[i]
+        stream_format = item.stream_formats[i]
+        channel_format = item.channel_formats[i]
+        track_uid = item.track_uids[i]
+
+        assert track_uid.trackIndex == track_index + 1
+        assert track_uid.audioPackFormat is item.pack_format
+        assert track_uid.audioTrackFormat is track_format
+
+        assert track_format.audioStreamFormat is stream_format
+
+        assert stream_format.audioChannelFormat is channel_format
+
+        assert channel_format.audioBlockFormats == channel_blocks
+        assert channel_format.audioChannelFormatName == f"myitem_{i+1}"
+
+    assert item.pack_format.audioChannelFormats == item.channel_formats
+
+    assert item.audio_object.audioPackFormats == [item.pack_format]
+    assert item.audio_object.audioTrackUIDs == item.track_uids
+
+    assert programme.audioContents == [content]
+    assert content.audioObjects == [item.audio_object]
+
+
+def test_mono():
+    builder = ADMBuilder()
+
+    programme = builder.create_programme(audioProgrammeName="programme")
+    content = builder.create_content(audioContentName="content")
+
+    block_formats = [
+        AudioBlockFormatObjects(
+            position=ObjectPolarPosition(azimuth=0.0, elevation=0.0, distance=1.0),
+        ),
+    ]
+    item = builder.create_item_objects(0, "MyObject 1", block_formats=block_formats)
+
+    assert item.track_uid.trackIndex == 1
+    assert item.track_uid.audioPackFormat is item.pack_format
+    assert item.track_uid.audioTrackFormat is item.track_format
+
+    assert item.track_format.audioStreamFormat is item.stream_format
+
+    assert item.stream_format.audioChannelFormat is item.channel_format
+
+    assert item.channel_format.audioBlockFormats == block_formats
+    assert item.channel_format.audioChannelFormatName == "MyObject 1"
+
+    assert item.pack_format.audioChannelFormats == [item.channel_format]
+
+    assert item.audio_object.audioPackFormats == [item.pack_format]
+    assert item.audio_object.audioTrackUIDs == [item.track_uid]
+
+    assert programme.audioContents == [content]
+    assert content.audioObjects == [item.audio_object]


### PR DESCRIPTION
A few related changes which make building ADM files with multi-channel streams much more pleasant when using `ear.fileio.adm.builder.Builder`:

- split MonoItem into format and content parts, Format and Item, to
  allow formats to be used more than once

    - can now use create_format_mono to create a format, and
      create_item_mono_from_format to use it

    - in the future we can add methods to extract a Format object from
      common definitions

    - to keep the API the same, properties are added to Item to access
      the format attributes which used to live directly in MonoItem

- Format and Item can hold multi-channel formats and contents

    - added multi-channel functions:

        - create_item_multichannel

        - create_format_multichannel

        - create_item_multichannel_from_format

    - added singular properties like track_uid which gets the single
      audioTrackUID out of track_uids

- added HOA helpers:

    - create_format_hoa

    - create_item_hoa

- added tests

