### PR TITLE
add absoluteDistance handling

### DIFF
--- a/ear/core/metadata_input.py
+++ b/ear/core/metadata_input.py
@@ -56,11 +56,13 @@ class ExtraData(object):
         object_duration (fractions.Fraction or None): Duration of audioObject.
         reference_screen (CartesianScreen or PolarScreen): Reference screen from audioProgramme.
         channel_frequency (Frequency): Frequency information from audioChannelFormat.
+        pack_absoluteDistance (float or None): absoluteDistance parameter from audioPackFormat.
     """
     object_start = attrib(validator=optional(instance_of(Fraction)), default=None)
     object_duration = attrib(validator=optional(instance_of(Fraction)), default=None)
     reference_screen = attrib(default=default_screen)
     channel_frequency = attrib(validator=instance_of(Frequency), default=Factory(Frequency))
+    pack_absoluteDistance = attrib(validator=optional(instance_of(float)), default=None)
 
 
 @attrs(slots=True)

--- a/ear/core/metadata_input.py
+++ b/ear/core/metadata_input.py
@@ -55,7 +55,7 @@ class ExtraData(object):
         object_start (fractions.Fraction or None): Start time of audioObject.
         object_duration (fractions.Fraction or None): Duration of audioObject.
         reference_screen (CartesianScreen or PolarScreen): Reference screen from audioProgramme.
-        channel_frequency (Frequency): Frequency information from audioChannel.
+        channel_frequency (Frequency): Frequency information from audioChannelFormat.
     """
     object_start = attrib(validator=optional(instance_of(Fraction)), default=None)
     object_duration = attrib(validator=optional(instance_of(Fraction)), default=None)

--- a/ear/core/select_items/hoa.py
+++ b/ear/core/select_items/hoa.py
@@ -1,9 +1,10 @@
 from functools import partial
 from ...fileio.adm.exceptions import AdmError
-
+from .utils import get_path_param
 
 # functions which take a path through the audioPackFormats and an
-# audioChannelFormat, and extract some parameter for a single HOA channel
+# audioChannelFormat, and extract some parameter for a single HOA channel, for
+# use with .utils.get_single_param and .utils.get_per_channel_param
 
 
 def _get_pack_param(audioPackFormat_path, audioChannelFormat, name, default=None):
@@ -13,23 +14,7 @@ def _get_pack_param(audioPackFormat_path, audioChannelFormat, name, default=None
     path from the root audioPackFormat to a single audioBlockFormat -- the
     consistency in the whole pack is checked in get_single_param."""
     path = audioPackFormat_path + [audioChannelFormat.audioBlockFormats[0]]
-    all_values = [getattr(obj, name) for obj in path]
-
-    not_none = [value for value in all_values if value is not None]
-
-    if not_none:
-        if any(value != not_none[0] for value in not_none):
-            raise AdmError(
-                "Conflicting {name} values in path from {apf.id} to {acf.id}".format(
-                    name=name,
-                    apf=audioPackFormat_path[0],
-                    acf=audioChannelFormat,
-                )
-            )
-
-        return not_none[0]
-    else:
-        return default
+    return get_path_param(path, name, default)
 
 
 def get_nfcRefDist(audioPackFormat_path, audioChannelFormat):
@@ -50,44 +35,3 @@ get_order = partial(_get_block_format_attr, attr="order")
 get_degree = partial(_get_block_format_attr, attr="degree")
 get_rtime = partial(_get_block_format_attr, attr="rtime")
 get_duration = partial(_get_block_format_attr, attr="duration")
-
-
-# functions to use the above definitions for multiple channels
-
-
-def get_single_param(pack_paths_channels, name, get_param):
-    """Get one parameter which must be consistent in all channels.
-
-    Parameters:
-        pack_paths_channels (list): list of tuples of (audioPackFormat_path,
-            audioChannelFormat), one for each audioChannelFormat in the root
-            audioPackFormat.
-        name (str): name of parameter to be used in exceptions
-        get_param (callable): function from (audioPackFormat_path,
-            audioChannelFormat) to the value of the parameter.
-    """
-    for pack_path_channel_a, pack_path_channel_b in zip(
-        pack_paths_channels[:-1], pack_paths_channels[1:]
-    ):
-        pack_format_path_a, channel_a = pack_path_channel_a
-        pack_format_path_b, channel_b = pack_path_channel_b
-        if get_param(pack_format_path_a, channel_a) != get_param(
-            pack_format_path_b, channel_b
-        ):
-            raise AdmError(
-                "All HOA audioChannelFormats in a single audioPackFormat must "
-                "share the same {name} value, but {acf_a.id} and {acf_b.id} differ.".format(
-                    name=name,
-                    acf_a=channel_a,
-                    acf_b=channel_b,
-                )
-            )
-
-    pack_path, channel = pack_paths_channels[0]
-    return get_param(pack_path, channel)
-
-
-def get_per_channel_param(pack_paths_channels, get_param):
-    """Get One value of a parameter per channel in pack_paths_channels.
-    See get_single_param."""
-    return [get_param(pack_path, channel) for pack_path, channel in pack_paths_channels]

--- a/ear/core/select_items/hoa.py
+++ b/ear/core/select_items/hoa.py
@@ -5,6 +5,7 @@ from ...fileio.adm.exceptions import AdmError
 # functions which take a path through the audioPackFormats and an
 # audioChannelFormat, and extract some parameter for a single HOA channel
 
+
 def _get_pack_param(audioPackFormat_path, audioChannelFormat, name, default=None):
     """Get a parameter which can be defined in either audioPackFormats or
     audioBlockFormats. Any specified parameters must be consistent. If none
@@ -18,11 +19,13 @@ def _get_pack_param(audioPackFormat_path, audioChannelFormat, name, default=None
 
     if not_none:
         if any(value != not_none[0] for value in not_none):
-            raise AdmError("Conflicting {name} values in path from {apf.id} to {acf.id}".format(
-                name=name,
-                apf=audioPackFormat_path[0],
-                acf=audioChannelFormat,
-            ))
+            raise AdmError(
+                "Conflicting {name} values in path from {apf.id} to {acf.id}".format(
+                    name=name,
+                    apf=audioPackFormat_path[0],
+                    acf=audioChannelFormat,
+                )
+            )
 
         return not_none[0]
     else:
@@ -51,6 +54,7 @@ get_duration = partial(_get_block_format_attr, attr="duration")
 
 # functions to use the above definitions for multiple channels
 
+
 def get_single_param(pack_paths_channels, name, get_param):
     """Get one parameter which must be consistent in all channels.
 
@@ -62,16 +66,22 @@ def get_single_param(pack_paths_channels, name, get_param):
         get_param (callable): function from (audioPackFormat_path,
             audioChannelFormat) to the value of the parameter.
     """
-    for pack_path_channel_a, pack_path_channel_b in zip(pack_paths_channels[:-1], pack_paths_channels[1:]):
+    for pack_path_channel_a, pack_path_channel_b in zip(
+        pack_paths_channels[:-1], pack_paths_channels[1:]
+    ):
         pack_format_path_a, channel_a = pack_path_channel_a
         pack_format_path_b, channel_b = pack_path_channel_b
-        if get_param(pack_format_path_a, channel_a) != get_param(pack_format_path_b, channel_b):
-            raise AdmError("All HOA audioChannelFormats in a single audioPackFormat must "
-                           "share the same {name} value, but {acf_a.id} and {acf_b.id} differ.".format(
-                               name=name,
-                               acf_a=channel_a,
-                               acf_b=channel_b,
-                           ))
+        if get_param(pack_format_path_a, channel_a) != get_param(
+            pack_format_path_b, channel_b
+        ):
+            raise AdmError(
+                "All HOA audioChannelFormats in a single audioPackFormat must "
+                "share the same {name} value, but {acf_a.id} and {acf_b.id} differ.".format(
+                    name=name,
+                    acf_a=channel_a,
+                    acf_b=channel_b,
+                )
+            )
 
     pack_path, channel = pack_paths_channels[0]
     return get_param(pack_path, channel)

--- a/ear/core/select_items/select_items.py
+++ b/ear/core/select_items/select_items.py
@@ -11,7 +11,8 @@ from ...fileio.adm.elements import (AudioProgramme, AudioContent, AudioObject,
                                     Frequency, TypeDefinition,
                                     )
 from .pack_allocation import allocate_packs, AllocationPack, AllocationChannel, AllocationTrack
-from .utils import in_by_id, object_paths_from, pack_format_paths_from
+from .utils import (get_path_param, get_per_channel_param, get_single_param,
+                    in_by_id, object_paths_from, pack_format_packs, pack_format_paths_from)
 from .validate import (validate_structure, validate_selected_audioTrackUID,
                        possible_reference_errors,
                        )
@@ -665,8 +666,7 @@ def _get_RenderingItems_DirectSpeakers(state):
 
 def _get_RenderingItems_HOA(state):
     """Get a HOARenderingItem given an _ItemSelectionState."""
-    from .hoa import (get_single_param, get_per_channel_param,
-                      get_nfcRefDist, get_screenRef, get_normalization,
+    from .hoa import (get_nfcRefDist, get_screenRef, get_normalization,
                       get_order, get_degree, get_rtime, get_duration)
 
     states = list(_select_single_channel(state))

--- a/ear/core/select_items/select_items.py
+++ b/ear/core/select_items/select_items.py
@@ -588,9 +588,28 @@ def _get_adm_path(state):
     )
 
 
-def _get_extra_data(state):
+def _get_extra_data(state, pack_paths_channels=None):
     """Get an ExtraData object for this track/channel with extra information
-    from the programme/object/channel needed for rendering."""
+    from the programme/object/channel needed for rendering.
+
+    This can be used in a single or multi-channel context:
+
+    - For single channels, pack_paths_channels is None and
+      state.audioPackFormat_path and state.audioChannelFormat are used.
+
+    - For multiple channels, pack_paths_channels is a list containing one tuple
+      per channel, each containing a list of audioPackFormats on the path
+      between the root audioPackFormat and the audioChannelFormat, and the
+      audioChannelFormat.
+    """
+    if pack_paths_channels is None:
+        assert state.audioPackFormat_path is not None
+        assert state.audioChannelFormat is not None
+        pack_paths_channels = [(state.audioPackFormat_path, state.audioChannelFormat)]
+
+    def get_absoluteDistance(audioPackFormat_path, audioChannelFormat):
+        return get_path_param(audioPackFormat_path, "absoluteDistance")
+
     return ExtraData(
         object_start=(state.audioObject.start
                       if state.audioObject is not None
@@ -604,6 +623,9 @@ def _get_extra_data(state):
         channel_frequency=(state.audioChannelFormat.frequency
                            if state.audioChannelFormat is not None
                            else Frequency()),
+        pack_absoluteDistance=get_single_param(pack_paths_channels,
+                                               "absoluteDistance",
+                                               get_absoluteDistance),
     )
 
 
@@ -682,7 +704,7 @@ def _get_RenderingItems_HOA(state):
         normalization=get_single_param(pack_paths_channels, "normalization", get_normalization),
         nfcRefDist=get_single_param(pack_paths_channels, "nfcRefDist", get_nfcRefDist),
         screenRef=get_single_param(pack_paths_channels, "screenRef", get_screenRef),
-        extra_data=_get_extra_data(state),
+        extra_data=_get_extra_data(state, pack_paths_channels),
     )
 
     metadata_source = MetadataSourceIter([type_metadata])

--- a/ear/core/select_items/test/test_hoa.py
+++ b/ear/core/select_items/test/test_hoa.py
@@ -127,6 +127,7 @@ def test_hoa_pack_params():
         pack.normalization = "N3D"
         pack.nfcRefDist = 1.0
         pack.screenRef = True
+        pack.absoluteDistance = 2.0
 
     for i, track in enumerate(builder.first_tracks, 1):
         builder.create_track_uid(audioPackFormat=builder.first_pack, audioTrackFormat=track,
@@ -139,3 +140,4 @@ def test_hoa_pack_params():
     assert meta.normalization == "N3D"
     assert meta.nfcRefDist == 1.0
     assert meta.screenRef is True
+    assert meta.extra_data.pack_absoluteDistance == 2.0

--- a/ear/core/select_items/test/test_validation.py
+++ b/ear/core/select_items/test/test_validation.py
@@ -384,6 +384,25 @@ def test_hoa_channel_format_mismatch():
         acf_b=builder.first_pack.audioChannelFormats[1])
 
 
+def test_hoa_pack_format_mismatch():
+    builder = HOABuilder()
+
+    builder.first_pack.absoluteDistance = 2.0
+
+    for i, track in enumerate(builder.first_tracks + builder.second_tracks):
+        builder.create_track_uid(
+            audioPackFormat=builder.second_pack, audioTrackFormat=track, trackIndex=i
+        )
+
+    check_select_items_raises(
+        builder,
+        "All audioChannelFormats in a single audioPackFormat must "
+        "share the same absoluteDistance value, but {acf_a.id} and {acf_b.id} differ.",
+        acf_a=builder.second_pack.audioChannelFormats[-1],
+        acf_b=builder.first_pack.audioChannelFormats[0],
+    )
+
+
 def test_matrix_one_block_format():
     builder = EncodeDecodeBuilder()
     del builder.encode_mid.audioBlockFormats[0]

--- a/ear/core/select_items/test/test_validation.py
+++ b/ear/core/select_items/test/test_validation.py
@@ -365,8 +365,8 @@ def test_hoa_pack_channel_mismatch():
 
     check_select_items_raises(
         builder,
-        "Conflicting normalization values in path from {apf.id} to {acf.id}",
-        apf=builder.first_pack, acf=channel_format)
+        "Conflicting normalization values in path from {apf.id} to {abf.id}",
+        apf=builder.first_pack, abf=block_format)
 
 
 def test_hoa_channel_format_mismatch():
@@ -378,7 +378,7 @@ def test_hoa_channel_format_mismatch():
 
     check_select_items_raises(
         builder,
-        "All HOA audioChannelFormats in a single audioPackFormat must "
+        "All audioChannelFormats in a single audioPackFormat must "
         "share the same normalization value, but {acf_a.id} and {acf_b.id} differ.",
         acf_a=builder.first_pack.audioChannelFormats[0],
         acf_b=builder.first_pack.audioChannelFormats[1])

--- a/ear/core/select_items/validate.py
+++ b/ear/core/select_items/validate.py
@@ -1,7 +1,8 @@
 from ...fileio.adm.elements import AudioPackFormat, AudioChannelFormat, TypeDefinition, ObjectCartesianPosition
 from ...fileio.adm.exceptions import AdmError
 from . import matrix
-from .utils import in_by_id, pack_format_channels, pack_format_packs, pack_format_paths_from
+from .utils import (get_single_param, in_by_id, pack_format_channels,
+                    pack_format_packs, pack_format_paths_from)
 
 
 def _validate_loops(type_name, nodes, get_children):
@@ -189,8 +190,8 @@ def _hoa_pack_format_paths_channels(adm):
 
 
 def _validate_hoa_parameters_consistent(adm):
-    from .hoa import (get_single_param, get_nfcRefDist, get_screenRef,
-                      get_normalization, get_rtime, get_duration)
+    from .hoa import (get_nfcRefDist, get_screenRef, get_normalization,
+                      get_rtime, get_duration)
 
     for pack_paths_channels in _hoa_pack_format_paths_channels(adm):
         get_single_param(pack_paths_channels, "rtime", get_rtime)


### PR DESCRIPTION
`absoluteDistance` isn't used by the renderer; this PR just puts the `absoluteDistance` parameter in the results of item selection so that it can be accessed more easily in other projects.

For single channels with a single audioPackFormat this is simple; the logic in other cases is as follows, in-line with how HOA parameters are determined:

For a single channel absoluteDistance can be specified in any of the audioPackFormats referencing it, and if it's specified more than once the values must be the same.

For multi-channel items (HOA), the single-channel rule applies for each channel, and the value determined for each channel must be the same.

This means that in the typical HOA structure with one pack per order (pointing to the channels for that order and a pack for the next order down), the absoluteDistance must be specified in the top-level pack, and if it's specified in the lower packs it must match.
