### PR TITLE
Warn about missing rtimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased Changes
+
+### Changed
+- Added a warning for audioBlockFormats which have a duration but no rtime; previously these were fixed silently. See [#54].
+
 ## [2.1.0] - 2022-01-26
 
 ### Fixed
@@ -143,6 +148,7 @@ Initial release.
 [#37]: https://github.com/ebu/ebu_adm_renderer/pull/37
 [#45]: https://github.com/ebu/ebu_adm_renderer/pull/45
 [#48]: https://github.com/ebu/ebu_adm_renderer/pull/48
+[#54]: https://github.com/ebu/ebu_adm_renderer/pull/54
 [34b738a]: https://github.com/ebu/ebu_adm_renderer/commit/34b738a
 [04533fc]: https://github.com/ebu/ebu_adm_renderer/commit/04533fc
 [222374a]: https://github.com/ebu/ebu_adm_renderer/commit/222374a

--- a/ear/fileio/adm/test/test_xml.py
+++ b/ear/fileio/adm/test/test_xml.py
@@ -732,6 +732,21 @@ def test_track_stream_ref(base):
                                              formatDefinition="PCM", formatLabel="0001")))
 
 
+def test_set_default_rtimes(base):
+    """Check that the audioBlockFormats with a duration but no rtime are given an rtime,
+    and a warning is issued.
+    """
+    with pytest.warns(
+        UserWarning,
+        match=(
+            "added missing rtime to AB_00031001_00000001; BS.2127-0 states "
+            "that rtime and duration should both be present or absent"
+        ),
+    ):
+        bf = base.bf_after_mods(del_attrs(bf_path, "rtime"))
+        assert bf.rtime == Fraction(0)
+
+
 def as_dict(inst):
     """Turn an adm element into a dict to be used for comparison.
 

--- a/ear/fileio/adm/xml.py
+++ b/ear/fileio/adm/xml.py
@@ -1157,6 +1157,10 @@ def _set_default_rtimes(channelFormats):
         for bf in channelFormat.audioBlockFormats:
             if bf.rtime is None and bf.duration is not None:
                 bf.rtime = Fraction(0)
+                warnings.warn(
+                    f"added missing rtime to {bf.id}; BS.2127-0 states that "
+                    "rtime and duration should both be present or absent"
+                )
 
 
 def load_axml_doc(adm, element, lookup_references=True, fix_block_format_durations=False):

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,41 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1649676176,
+        "narHash": "sha256-OWKJratjt2RW151VUlJPRALb7OU2S5s+f0vLj4o1bHM=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "a4b154ebbdc88c8498a5c7b01589addc9e9cb678",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1651804312,
+        "narHash": "sha256-DJxOGlxwQccuuwXUS0oRRkcNJbW5UP4fpsL5ga9ZwYw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d59dd43e49f24b58fe8d5ded38cbdf00c3da4dc2",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,35 @@
+{
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem
+      (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          python3 = pkgs.python3;
+        in
+        rec {
+          packages.ear = python3.pkgs.buildPythonPackage rec {
+            name = "ear";
+            src = ./.;
+            propagatedBuildInputs = with python3.pkgs; [ numpy scipy enum34 six attrs multipledispatch lxml ruamel_yaml setuptools ];
+            doCheck = true;
+            checkInputs = with python3.pkgs; [ pytest soundfile ];
+            postPatch = ''
+              # latest attrs should be fine...
+              sed -i "s/'attrs.*'/'attrs'/" setup.py
+            '';
+          };
+          defaultPackage = packages.ear;
+
+          devShells.ear = packages.ear.overridePythonAttrs (attrs: {
+            propagatedBuildInputs = attrs.propagatedBuildInputs ++ [
+              python3.pkgs.matplotlib
+            ];
+            # dontUseSetuptoolsShellHook = true;
+          });
+          devShell = devShells.ear;
+        }
+      );
+}
+


### PR DESCRIPTION
add a warning for missing rtime in blocks with duration

These were previously fixed silently, but BS.2127-0 says that this is an error. Arguably that could be relaxed, but we should follow the standard.