### PR TITLE
Fix CI Build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,10 @@ jobs:
         python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
 
@@ -27,7 +27,7 @@ jobs:
         run: tox -e py
 
       - name: Upload Coverage
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-${{ matrix.python }}
           # use a wildcard so that the archives have a folder in the root

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
* Update CI actions to v6 (v2 has been retired)
* Remove versions of python that are no longer supported from build matrix (3.8 and 3.9)

Note that I initially attempted to add 3.14 (the latest release), however the build failed due to a use of the removed `ast.Str` 

It's possible this can be solved by updating pytest (appeared to be the source of the problem), but I left it as that's a separate issue to CI.
